### PR TITLE
Add imageRelativePath to Reply

### DIFF
--- a/message.js
+++ b/message.js
@@ -116,6 +116,7 @@ class Reply {
         const replyOptions = options.replies[0]; // todo fix if aborted
         this.text = replyOptions.text
         this.id = replyOptions.id
+        this.imageRelativePath = replyOptions.image_rel_path
 
         const srcCharacterDict = options.src_char;
         this.srcCharacterName = srcCharacterDict.participant.name


### PR DESCRIPTION
Small change to add `imageRelativePath` to the `Reply` class from `replyOptions.image_rel_path` for characters that can respond with an image.

Example character to test with: https://beta.character.ai/chat?char=bQBlcCVVjfTAzv8OWK30dw7Tj-TNtKC_Rh0Z46Dx6fY

Addresses one part of https://github.com/realcoloride/node_characterai/issues/33