### PR TITLE
Fix no chat history detection (createOrContinueChat issue)

### DIFF
--- a/client.js
+++ b/client.js
@@ -146,7 +146,7 @@ class Client {
             if (response.startsWith("no character found for"))
                 throw Error("Character with this id was not found");
 
-            if (response === "No Such History" || response === "there is no history between user and character") { // Create a new chat
+            if (response === "history not found." || response === "No Such History" || response === "there is no history between user and character") { // Create a new chat
                 request = await this.requester.request("https://beta.character.ai/chat/history/create/", {
                     body: Parser.stringify({
                         character_external_id: characterId,


### PR DESCRIPTION
Recently tried to create a new chat (not existing), and find some weird error.
![image](https://github.com/realcoloride/node_characterai/assets/82355841/1c1b636c-0796-4fa5-949c-8afafc3ea0b6)

After searching for a while, it seems like another miss in the code where it should attempt to create new one, but instead use a non existing chat because of an unhandled response.
![image](https://github.com/realcoloride/node_characterai/assets/82355841/95fac71e-cbce-4187-b7c9-c278b2ce5021)

Seems like a simple fix, since modifying to add that unhandled response seems to work.
![image](https://github.com/realcoloride/node_characterai/assets/82355841/0d552394-98cc-4808-a0f9-48c8c4e05348)
![image](https://github.com/realcoloride/node_characterai/assets/82355841/77fec5b5-44a4-45e0-9b79-8587d2a3d099)