### PR TITLE
Fixed Error: Failed opening websocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node_characterai",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node_characterai",
-      "version": "2.0.0-beta.5",
+      "version": "2.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@livekit/rtc-node": "^0.12.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -81,7 +81,7 @@ export class CharacterAI {
                 includeAuthorization: false
             });
             const { headers } = request;
-            let edgeRollout = headers.get("set-cookie")?.match(/edge_rollout=(\d+)/)?.at(1);
+            let edgeRollout = headers.get("set-cookie")?.match(/edge_rollout=([^;]+)/)?.at(1);
             if (!edgeRollout) {
                 if (!request.ok) throw Error("Could not get edge rollout");
                 edgeRollout = fallbackEdgeRollout;


### PR DESCRIPTION
- Error: Could not get edge rollout / when auth with token  <--- Fixed undefined regex
- I guess Character AI has set edgeRollout=NaN; if the returned value equals its own value, we can authenticate successfully