### PR TITLE
add streaming support for sendMessage and websocket handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Node related
 /old/
 /dist/
-/node_modules/
+node_modules/
 
 # Testing script
 example.ts
@@ -14,3 +14,4 @@ test.pcm
 
 # Crash dump
 crash.log
+

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ avatar.png
 bush.wav
 test.pcm
 crash.log
+tests

--- a/src/character/character.ts
+++ b/src/character/character.ts
@@ -151,7 +151,7 @@ export class Character extends Specable {
     @hiddenProperty
     private participant__name?: string = undefined;
     @hiddenProperty
-    private name?: string = undefined;
+    public name?: string = undefined;
     @hiddenProperty
     private participant__user__username?: string = undefined;
     @hiddenProperty
@@ -279,7 +279,11 @@ export class Character extends Specable {
                 }
             })
 
-            conversation = new DMConversation(this.client, request[0].chat);
+            {
+                const r = request as { chat: unknown } | Array<{ chat: unknown }>;
+                const chatObj = Array.isArray(r) ? r[0].chat : r.chat;
+                conversation = new DMConversation(this.client, chatObj);
+            }
         }
 
         // if no chat id after allat, lets fetch the most recent one

--- a/src/chat/message.ts
+++ b/src/chat/message.ts
@@ -171,7 +171,12 @@ export class CAIMessage extends Specable {
 
         }
 
-        this.candidates = request.pop().turn.candidates;
+        type Turn = { candidates: Candidate[] };
+
+        const r = request as { turn: Turn } | Array<{ turn: Turn }>;
+        const pkt = Array.isArray(r) ? r[r.length - 1] : r;
+        this.candidates = pkt.turn.candidates;
+
         this.indexCandidates();
     }
     // next/previous/candidate_id

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,23 +36,26 @@ export class CharacterAI {
     async sendDMWebsocketAsync(options: ICAIWebsocketMessage) { 
         return await this.dmChatWebsocket?.sendAsync(options); 
     }
-    async sendDMWebsocketCommandAsync(options: ICAIWebsocketCommand) {
-        const requestId = uuidv4();
-        return await this.sendDMWebsocketAsync({
-            parseJSON: true,
-            expectedReturnCommand: options.expectedReturnCommand,
-            messageType: CAIWebsocketConnectionType.DM,
-            waitForAIResponse: options.waitForAIResponse ?? true,
-            expectedRequestId: requestId,
-            streaming: options.streaming,
-            data: Parser.stringify({
-                command: options.command,
-                origin_id: options.originId,
-                payload: options.payload,
-                request_id: requestId
-            })
-        });
-    }
+async sendDMWebsocketCommandAsync(options: ICAIWebsocketCommand) {
+  const requestId = uuidv4();
+  return await this.sendDMWebsocketAsync({
+    parseJSON: true,
+    expectedReturnCommand: options.expectedReturnCommand,
+    messageType: CAIWebsocketConnectionType.DM,
+    waitForAIResponse: options.waitForAIResponse ?? true,
+    expectedRequestId: requestId,
+    streaming: options.streaming,
+    onStream: options.onStream,
+    expectedTurnId: options.expectedTurnId,
+    expectedChatId: options.expectedChatId,
+    data: Parser.stringify({
+      command: options.command,
+      origin_id: options.originId,
+      payload: options.payload,
+      request_id: requestId
+    })
+  });
+}
 
     private groupChatWebsocket: CAIWebsocket | null = null;
     async sendGroupChatWebsocketAsync(options: ICAIWebsocketMessage) { this.groupChatWebsocket?.sendAsync(options); }

--- a/src/utils/patcher.ts
+++ b/src/utils/patcher.ts
@@ -3,6 +3,7 @@ import { CAIImage } from "./image";
 
 export default class ObjectPatcher {
     static patch(client: CharacterAI, instance: any, object: Record<string, any>) {
+        if(!object) return;
         const avatarFileName = object["avatar_file_name"] || object["character_avatar_uri"];
         if (avatarFileName) {
             const avatar = new CAIImage(client, false);

--- a/tests/current/main.test.ts
+++ b/tests/current/main.test.ts
@@ -1,0 +1,110 @@
+import { CharacterAI } from "../../src";
+
+const characterAI = new CharacterAI()
+const { default: chalk } = require('chalk');
+
+
+async function StartNewConversation() {
+
+    const client = await UseAuth()
+    const character1 = await client.fetchCharacter("xnSbLWXop06fpWEKz-VKImTjIgQw3-PiRGmqfoziFFA") // Chino kafuu
+
+    // Create DM
+    const dm1 = await character1.createDM(true)
+    console.log(`[${chalk.blue(character1.name)}] chatId: ${chalk.green(dm1.chatId)}\n\n${character1?.greeting}`)
+    // You can continue any existing session by providing the chatId and characterId
+    // check the examples bellow!
+}
+
+async function ContinueChatSessionAsync() {
+    const client = await UseAuth()
+
+    const character1 = await client.fetchCharacter("xnSbLWXop06fpWEKz-VKImTjIgQw3-PiRGmqfoziFFA") // Chino kafuu
+
+    // Open DM
+    const dm1 = await character1.DM('7120fb28-6552-44b8-ac37-3b5329ed367e')
+
+    const send1 = await dm1.sendMessage('nikah yuk >.<')
+
+    console.log(chalk.blue(`\n[${character1.name}]`), chalk.green(send1.content));
+
+}
+
+async function ContinueChatSessionStreamSync() {
+    const client = await UseAuth()
+
+    const character1 = await client.fetchCharacter("xnSbLWXop06fpWEKz-VKImTjIgQw3-PiRGmqfoziFFA") // Chino kafuu
+
+    // Create DM
+    const dm1 = await character1.DM('7120fb28-6552-44b8-ac37-3b5329ed367e')
+    
+    // Register event emiter, this will capture the response of .sendMessage that uses { streameMessage: true }
+    dm1.on('message:delta',(full: string, delta: string) => {
+
+    // 'full' is the accumulation of character messages, and delta is fragment of words (not always)
+    console.log(chalk.blue(`[${character1.name}]`), chalk.green(full));
+    // This should be print lines like this
+    // [Chino Kafuu] \*She looks around in embarrassment and clears her throat, looking back at you\*
+    // [Chino Kafuu] \*She looks around in embarrassment and clears her throat, looking back at you\* 
+    //  Uh.. a-Are you.... p-proposing to me?
+    })
+
+
+    // never use await if you wish to handle streamMessage 
+    const send1 = dm1.sendMessage('aloooowww >.<',
+          {
+            streamMessage: true // THIS, will be exposes the message to ev emit
+          }
+    )
+    const send2 = dm1.sendMessage('nikah yuk >.< ', 
+        {
+            streamMessage: true
+        }
+    )
+
+    // lets see the characters final message
+    const res1 = await send1
+    const res2 = await send2
+
+    console.log(chalk.blue(`\n\n[${character1.name}]`), chalk.green(res1.content));
+    console.log(chalk.blue(`[${character1.name}]`), chalk.green(res2.content));
+
+}
+
+let ready = false;
+
+
+async function UseAuth() {
+    if (ready) return characterAI;
+
+    const token =
+      process.env.CAI_ACCESS_TOKEN ||
+      process.env.CAI_TOKEN ||
+      process.env.CAI_APIKEY ||
+      process.env.CAI_SESSION_TOKEN;
+
+    if (!token) {
+      console.log(chalk.red("Please run this test by set CAI_ACCESS_TOKEN on environtment."))
+      process.exit()
+    }
+
+    let auth
+
+    try{
+    auth = await characterAI.authenticate(token)
+    ready = true
+
+    } catch {
+      ready = false
+      throw Error()
+    }
+  
+    return auth;
+}
+
+
+
+StartNewConversation()
+// ContinueChatSessionAsync()
+// ContinueChatSessionStreamSync()
+


### PR DESCRIPTION
it seemed like a good idea to add streaming support for character messages,
so I went ahead and implemented it

changes include:

- Extended sendMessage with streaming callbacks (onText, onPacket)
- Added support for expectedTurnId and expectedChatId
- Updated websocket layer to emit deltaText and final events
- Refactored client to properly pass onStream handlers

note: i'm not entirely sure if a similar feature already exists,
but i couldn't find it myself, so I decided to add this anyway

thanks!